### PR TITLE
fix bugs and add new post-processing

### DIFF
--- a/nn.py
+++ b/nn.py
@@ -16,7 +16,7 @@ import datetime
 
 ##remove these
 #import main_
-#os.environ["CUDA_VISIBLE_DEVICES"]=""
+#os.environ["CUDA_VISIBLE_DEVICES"]="9"
 validation_check = True
 
 num_feature = 15+4+45+5
@@ -360,7 +360,7 @@ if __name__ == '__main__':
     if pretrained:
         print('testing')
         for tst_file in args.tst:
-            data_tst = pd.read_csv(tst_file[:-4]+'_processed.csv')
+            #data_tst = pd.read_csv(tst_file[:-4]+'_processed.csv')
             X, _ = genData([tst_file], app_name, proto_name, False)
             for x_i in range(15):
                 X[:, x_i] = (X[:, x_i])/norm_std[x_i]
@@ -396,8 +396,8 @@ if __name__ == '__main__':
                 label_map = {0: 'DDOS-smurf', 1: 'Normal', 2: 'Probing-IP sweep', 3: 'Probing-Nmap', 4: 'Probing-Port sweep'}
                 test['label'] = ans['pred']
                 test['label'] = test['label'].apply(lambda x: label_map[x])
-                dat_tst = data_tst.copy()
-                main_.evaluation(dat_tst, y_pred)
+                #dat_tst = data_tst.copy()
+                #main_.evaluation(dat_tst, y_pred)
                 if time_setting == 'minute':
                     test.to_csv(tst_file[:-4]+'_'+time_setting+'_nn_predicted.csv', index=False)
                 elif time_setting == 'hour':


### PR DESCRIPTION
我發現少存到一個one-hot encoder，已經修改好並且改成新的post-processing
舊/新的post-processing 結果如下
```
[[     17    1008       0       0       8]
 [     25 3142083   21601       0     667]
 [      0     816   58754      68     261]
 [      0       0      14      95       0]
 [      0       0     488     237    7919]]
              precision    recall  f1-score   support

           0    0.40476   0.01646   0.03163      1033
           1    0.99942   0.99296   0.99618   3164376
           2    0.72664   0.98088   0.83483     59899
           3    0.23750   0.87156   0.37328       109
           4    0.89430   0.91613   0.90508      8644

   micro avg    0.99221   0.99221   0.99221   3234061
   macro avg    0.65252   0.75560   0.62820   3234061
weighted avg    0.99387   0.99221   0.99262   3234061

macro F beta score:  0.6822393483949998
cost matrix:  [[    0  2016     0     0     8]
 [   50     0 21601     0   667]
 [    0   816     0    68   261]
 [    0     0    14     0     0]
 [    0     0   488   237     0]]
total cost:  26226
max cost:  21601
log total / log max:  1.0194390836681146
Evaluation criteria:  0.4717358187760654
```

```
[[     17    1012       0       0       4]
 [     25 3154233    9679       0     439]
 [      0       5   59533      68     293]
 [      0       0      14      95       0]
 [      0       0     131     241    8272]]
              precision    recall  f1-score   support

           0    0.40476   0.01646   0.03163      1033
           1    0.99968   0.99679   0.99823   3164376
           2    0.85836   0.99389   0.92116     59899
           3    0.23515   0.87156   0.37037       109
           4    0.91829   0.95696   0.93723      8644

   micro avg    0.99632   0.99632   0.99632   3234061
   macro avg    0.68325   0.76713   0.65173   3234061
weighted avg    0.99663   0.99632   0.99631   3234061

macro F beta score:  0.6991292111263412
cost matrix:  [[   0 2024    0    0    4]
 [  50    0 9679    0  439]
 [   0    5    0   68  293]
 [   0    0   14    0    0]
 [   0    0  131  241    0]]
total cost:  12948
max cost:  9679
log total / log max:  1.0317053625821986
Evaluation criteria:  0.47987883901377926
```